### PR TITLE
Add link to marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Provides intellisense, search and hover preview of Material Design Icons.
 
 This extension provides intellisense for both `@mdi/font` and `@mdi/js`. Due to the size of the webfont, you should consider using `@mdi/js` (read [this guide](https://dev.materialdesignicons.com/guide/webfont-alternatives) for further information).
 
+[Install from VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=lukas-tr.materialdesignicons-intellisense)
+
 ## Features
 
 Starts suggesting icon names after typing `mdi` (camelCase), `mdi-` (kebab-case) or `mdi:` (YAML/Home Assistant). Each entry contains a preview image and other information related to the icon, such as the icon category or aliases.


### PR DESCRIPTION
Don't let interesting users search for where to install. Let them click to it right away.

Great work on this btw! I just promoted it on the @home-assistant social media https://twitter.com/home_assistant/status/1105582243014234112