### PR TITLE
Add Support for Home Assistant Config Helper Extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,8 @@
                             "vue-html",
                             "vue",
                             "ng-template",
-                            "yaml"
+                            "yaml",
+                            "home-assistant"
                         ],
                         "items": {
                             "type": "string"


### PR DESCRIPTION
The Home Assistant Config Helper extension creates its own language server for Home Assistant YAML files. This doesn't work with the MDI Intellisense extension by default. Adding `home-assistant` to `"materialdesigniconsIntellisense.selector"` fixes this.